### PR TITLE
Fix: Align GPLv3 license application with best practices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -632,7 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2025  huiyadanli
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    RevokeMsgPatcher  Copyright (C) 2025  huiyadanli
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
您好！首先，非常感谢您为这个项目所付出的努力！

我注意到项目在使用 GPLv3 许可证的方式上有一个可以优化的地方，因此提交了这个小小的修复。

### 问题说明

目前，项目根目录下的 `LICENSE` 文件似乎被修改过，在其附录部分加入了本项目的版权信息。根据 GNU GPL 自身的条款，许可证的文本原文应作为**未经修改的副本**进行分发，因为其版权属于自由软件基金会 (FSF)。

### 这个 PR 做了什么

本次 PR 只做了一件事：将项目根目录的 `LICENSE` 文件内容**恢复为了官方、未经修改的 GPLv3 原始文本**。这是确保项目授权合规的第一步。

### 后续建议 (需要您来完成)

为了让整个授权流程完全符合 GPL 的指引，还需要完成第二步：**将项目的版权声明以“注释头”的形式添加到每个 C# 源代码文件 (`.cs` 文件) 的顶部**。

这是 GPL 协议推荐的、项目声明自身版权的正确位置。您可以考虑在合并此 PR 后，将以下模板添加到您的 C# 代码文件中：

```csharp
/* [项目名称] - [项目的一句话描述]
 * Copyright (C) 2025 huiyadanli
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */